### PR TITLE
Any change to the runtime or common properties now triggers a refresh…

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -38,6 +38,7 @@ define druid::service (
     ensure  => file,
     content => $config_content,
     require => File["${druid::config_dir}/${service_name}"],
+    notify  => Exec["Reload systemd daemon for new ${service_name} service config"],
   }
 
   file { "${druid::config_dir}/${service_name}/common.runtime.properties":
@@ -47,15 +48,16 @@ define druid::service (
       File["${druid::config_dir}/${service_name}"],
       File["${druid::config_dir}/common.runtime.properties"],
     ],
+    notify  => Exec["Reload systemd daemon for new ${service_name} service config"],
   }
 
   file { "/etc/systemd/system/druid-${service_name}.service":
     ensure  => file,
     content => $service_content,
-    notify  => Exec["Reload systemd daemon for new ${service_name} service file"],
+    notify  => Exec["Reload systemd daemon for new ${service_name} service config"],
   }
 
-  exec { "Reload systemd daemon for new ${service_name} service file":
+  exec { "Reload systemd daemon for new ${service_name} service config":
     command     => '/bin/systemctl daemon-reload',
     refreshonly => true,
   }
@@ -65,6 +67,6 @@ define druid::service (
     enable    => true,
     provider  => 'systemd',
     require   => File["/etc/systemd/system/druid-${service_name}.service"],
-    subscribe => Exec["Reload systemd daemon for new ${service_name} service file"],
+    subscribe => Exec["Reload systemd daemon for new ${service_name} service config"],
   }
 }


### PR DESCRIPTION
… of the service.

Instead of only triggering it when the service definition changed (which only happens when jvm_opts or extra_classpaths is tweaked)